### PR TITLE
Refine code style rules

### DIFF
--- a/CXL/ruleset.xml
+++ b/CXL/ruleset.xml
@@ -88,6 +88,15 @@
 
         <!-- There is some unconventional use for inline scripts. -->
         <exclude name="WordPress.WP.EnqueuedResourceParameters" />
+
+        <!-- Escaping is too complicated for reliable automation. -->
+        <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
+
+        <!-- Intentionally used in several places. -->
+        <exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited" />
+
+        <!-- Used quite a bit, needs either careful rework or nto careful bulk change to gmdate(). -->
+        <exclude name="WordPress.DateTime.RestrictedFunctions.date_date" />
     </rule>
 
     <!--

--- a/CXL/ruleset.xml
+++ b/CXL/ruleset.xml
@@ -97,6 +97,10 @@
 
         <!-- Used quite a bit, needs either careful rework or nto careful bulk change to gmdate(). -->
         <exclude name="WordPress.DateTime.RestrictedFunctions.date_date" />
+
+		<!-- Unnecessary for typed properties. -->
+        <exclude name="Squiz.Commenting.VariableComment.Missing" />
+        <exclude name="Squiz.Commenting.VariableComment.MissingVar" />
     </rule>
 
     <!--

--- a/CXL/ruleset.xml
+++ b/CXL/ruleset.xml
@@ -4,15 +4,41 @@
     <!-- Spaces, not tabs. -->
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
 
-    <!--
-    We may also want to to include all the rules in WP standard.
-    -->
-    <rule ref="WordPress-Core">
+    <rule ref="WordPress">
         <!-- Spaces, not tabs. -->
         <exclude name="Generic.WhiteSpace.DisallowSpaceIndent"/>
-    </rule>
 
-    <rule ref="WordPress-Extra">
+        <!-- WP filename conventions are incompatible w/ Composer PSR-4 autoloader. -->
+        <exclude name="WordPress.Files.FileName"/>
+
+        <!-- Short array syntax ftw. -->
+        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
+
+        <!-- Short ternary ftw. -->
+        <exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+
+        <!--
+        "So far I have not found a use for file-level DocBlocks in closed-source software."
+        @see https://localheinz.com/blog/2018/05/06/cost-and-value-of-docblocks/
+        -->
+        <exclude name="Squiz.Commenting.FileComment.Missing"/>
+        <exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
+
+        <!-- Usually just repeats the obvious. -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+
+        <!-- `//end if` looks silly. -->
+        <exclude name="Squiz.Commenting.LongConditionClosingComment.Missing"/>
+
+        <!-- Sometimes useful to describe array members. -->
+        <exclude name="Squiz.Commenting.PostStatementComment.Found"/>
+
+        <!-- Often just /** @since */ is enough. -->
+        <exclude name="Generic.Commenting.DocComment.MissingShort"/>
+
+        <!-- /** @todo */ is useful. -->
+        <exclude name="Generic.Commenting.Todo.CommentFound"/>
+        <exclude name="Generic.Commenting.Todo.TaskFound"/>
     </rule>
 
     <!--
@@ -30,17 +56,6 @@
         <properties>
             <property name="blank_line_after_check" value="0"/>
         </properties>
-    </rule>
-
-    <rule ref="WordPress">
-        <!-- WP filename conventions are incompatible w/ Composer PSR-4 autoloader. -->
-        <exclude name="WordPress.Files.FileName"/>
-
-        <!-- Short array syntax ftw. -->
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
-
-        <!-- Short ternary ftw. -->
-        <exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
     </rule>
 
     <!--
@@ -72,32 +87,6 @@
     </rule>
     <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
         <severity>0</severity>
-    </rule>
-
-    <rule ref="Squiz.Commenting">
-        <!--
-        "So far I have not found a use for file-level DocBlocks in closed-source software."
-        @see https://localheinz.com/blog/2018/05/06/cost-and-value-of-docblocks/
-        -->
-        <exclude name="Squiz.Commenting.FileComment.Missing"/>
-        <exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
-
-        <!-- Usually just repeats the obvious. -->
-        <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
-
-        <!-- `//end if` looks silly. -->
-        <exclude name="Squiz.Commenting.LongConditionClosingComment.Missing"/>
-
-        <!-- Sometimes useful to describe array members. -->
-        <exclude name="Squiz.Commenting.PostStatementComment.Found"/>
-    </rule>
-
-    <rule ref="Generic.Commenting">
-        <!-- Often just /** @since */ is enough. -->
-        <exclude name="Generic.Commenting.DocComment.MissingShort"/>
-        <!-- /** @todo */ is useful. -->
-        <exclude name="Generic.Commenting.Todo.CommentFound"/>
-        <exclude name="Generic.Commenting.Todo.TaskFound"/>
     </rule>
 
 </ruleset>

--- a/CXL/ruleset.xml
+++ b/CXL/ruleset.xml
@@ -39,6 +39,35 @@
         <!-- /** @todo */ is useful. -->
         <exclude name="Generic.Commenting.Todo.CommentFound"/>
         <exclude name="Generic.Commenting.Todo.TaskFound"/>
+
+        <!-- Core naming rules are too rigid and don't work well in other projects. -->
+        <exclude name="WordPress.NamingConventions.ValidVariableName"/>
+
+        <!-- Often complains about non-issues. -->
+        <exclude name="WordPress.Security.NonceVerification.Recommended"/>
+        <exclude name="WordPress.Security.ValidatedSanitizedInput" />
+
+        <!-- Unnecessary on simple methods. -->
+        <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+
+        <!-- Unnecessary more often than not. -->
+        <exclude name="Squiz.Commenting.ClassComment"/>
+
+        <!-- Not an actual problem. -->
+        <exclude name="Squiz.PHP.CommentedOutCode.Found"/>
+
+        <!-- Complains when there is a comment on top that is NOT a file comment. -->
+        <exclude name="Squiz.Commenting.FileComment.SpacingAfterComment"/>
+
+        <!-- Complains about URLs and other perfectly normal uses. -->
+        <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+        <exclude name="Generic.Commenting.DocComment.ShortNotCapital"/>
+
+        <!-- Git on Windows checks out Windows, commits Linux line endings by defaults. -->
+        <exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
+
+        <!-- Upstream translated strings. -->
+        <exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
     </rule>
 
     <!--
@@ -86,6 +115,11 @@
         <severity>0</severity>
     </rule>
     <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
+        <severity>0</severity>
+    </rule>
+
+    <!-- False positive on failed symlinks on Windows. -->
+    <rule ref="Internal.NoCodeFound">
         <severity>0</severity>
     </rule>
 

--- a/CXL/ruleset.xml
+++ b/CXL/ruleset.xml
@@ -25,6 +25,7 @@
         <exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
 
         <!-- Usually just repeats the obvious. -->
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
 
         <!-- `//end if` looks silly. -->
@@ -68,6 +69,25 @@
 
         <!-- Upstream translated strings. -->
         <exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
+
+        <!-- Often redundant. -->
+        <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
+
+        <!-- Doesn't make sense outside of core. -->
+        <exclude name="WordPress.DB.DirectDatabaseQuery" />
+        <exclude name="WordPress.DB.SlowDBQuery" />
+
+        <!-- Localization not relevant for the moment. -->
+        <exclude name="WordPress.WP.I18n" />
+
+        <!-- A cryptic and unproductive white space sniff. -->
+        <exclude name="WordPress.WhiteSpace.PrecisionAlignment" />
+
+        <!-- Used on purpose for logging. -->
+        <exclude name="WordPress.PHP.DevelopmentFunctions" />
+
+        <!-- There is some unconventional use for inline scripts. -->
+        <exclude name="WordPress.WP.EnqueuedResourceParameters" />
     </rule>
 
     <!--


### PR DESCRIPTION
Work in progress.

Refactoring and more suggestions on rules to ignore.

Worked through theme lib and theme, plugin up next.

## Up for discussion

- `WordPress.Security.EscapeOutput.OutputNotEscaped` unfortunately it’s impossible for automated sniff to sort this out with reasonable accuracy, escaping is important but just doesn't mesh well with automation (in lack of by default template level escaping in WP).
- `WordPress.WP.GlobalVariablesOverride.Prohibited` several places purposely change core globals (mostly `$post`) not sure if it should be touched.
- `WordPress.DateTime.RestrictedFunctions.date_date` this one is complicated. Under normal operation it should be `gmdate()` because WP core sets PHP time zone to UTC and `date()` breaks when someone is messing with it. However when someone is messing with it and _relies_ on it then _core-correct_ `gmdate()` breaks. A lot of `date()` in the plugin right now.