### PR TITLE
CXL-Jobs ruleset.

### DIFF
--- a/CXL-Jobs/CXL-Jobs
+++ b/CXL-Jobs/CXL-Jobs
@@ -1,0 +1,1 @@
+CXL-Jobs

--- a/CXL-Jobs/ruleset.xml
+++ b/CXL-Jobs/ruleset.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<ruleset name="CXL-Jobs">
+
+    <!-- Tabs, not spaces. -->
+    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed"/>
+
+    <!-- CamelCase() not snake_case(). -->
+    <rule ref="PSR1.Methods.CamelCapsMethodName"></rule>
+
+    <!--
+    We may also want to to include all the rules in WP standard.
+    -->
+    <rule ref="WordPress-Core">
+        <!-- CamelCase() not snake_case(). -->
+        <exclude name="WordPress.NamingConventions.ValidFunctionName"></exclude>
+    </rule>
+
+    <rule ref="WordPress-Extra">
+    </rule>
+
+    <!--
+    Allow wider vertical spacing coding style:
+    ```php
+        ...
+        if ( foo ) {
+            bar();
+        }
+
+    }
+    ```
+    -->
+    <rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
+        <properties>
+            <property name="blank_line_after_check" value="0"/>
+        </properties>
+    </rule>
+
+    <rule ref="WordPress">
+        <!-- WP filename conventions are incompatible w/ Composer PSR-4 autoloader. -->
+        <exclude name="WordPress.Files.FileName"/>
+
+        <!-- Short array syntax ftw. -->
+        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
+
+        <!-- Short ternary ftw. -->
+        <exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+    </rule>
+
+    <!--
+    Custom templating frameworks etc.
+    @see https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#xss-custom-printing-functions
+    @todo Method elements don't work!
+    -->
+    <rule ref="WordPress.Security.EscapeOutput">
+        <properties>
+            <property name="customAutoEscapedFunctions" type="array">
+                <element value="cxli"/>
+                <element value="get_view_instance"/>
+                <element value="render"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!--
+    Allow `add_action( 'tag', function() {
+    } );
+    @see https://github.com/squizlabs/PHP_CodeSniffer/issues/2001
+    @see https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1485
+    -->
+    <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.MultipleArguments">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
+        <severity>0</severity>
+    </rule>
+
+    <rule ref="Squiz.Commenting">
+        <!--
+        "So far I have not found a use for file-level DocBlocks in closed-source software."
+        @see https://localheinz.com/blog/2018/05/06/cost-and-value-of-docblocks/
+        -->
+        <exclude name="Squiz.Commenting.FileComment.Missing"/>
+        <exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
+
+        <!-- Usually just repeats the obvious. -->
+        <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+
+        <!-- `//end if` looks silly. -->
+        <exclude name="Squiz.Commenting.LongConditionClosingComment.Missing"/>
+
+        <!-- Sometimes useful to describe array members. -->
+        <exclude name="Squiz.Commenting.PostStatementComment.Found"/>
+    </rule>
+
+    <rule ref="Generic.Commenting">
+        <!-- Often just /** @since */ is enough. -->
+        <exclude name="Generic.Commenting.DocComment.MissingShort"/>
+        <!-- /** @todo */ is useful. -->
+        <exclude name="Generic.Commenting.Todo.CommentFound"/>
+        <exclude name="Generic.Commenting.Todo.TaskFound"/>
+    </rule>
+
+    <!--
+    @see https://github.com/sirbrillig/phpcs-variable-analysis
+    -->
+    <rule ref="VariableAnalysis"/>
+
+</ruleset>


### PR DESCRIPTION
Ruleset for CXL Jobs project based on `CXL` ruleset with following changes:
* tabs not spaces,
* `camelCase()` not `snake_case()` methods.

See https://github.com/conversionxl/jobs-theme/issues/20