### PR TITLE
Refine SlevomatCodingStandard.* rules

### DIFF
--- a/CXL/ruleset.xml
+++ b/CXL/ruleset.xml
@@ -114,8 +114,12 @@
     -->
     <rule ref="SlevomatCodingStandard">
         <exclude name="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
+        <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaMagicConstant"/>
+        <exclude name="SlevomatCodingStandard.Classes.ParentCallSpacing.IncorrectLinesCountAfterLastControlStructure"/>
         <exclude name="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode"/>
+        <exclude name="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment.OneLinePropertyComment"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/>
+        <exclude name="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator.DisallowedShortTernaryOperator"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.NewWithoutParentheses"/>
@@ -126,9 +130,10 @@
         <exclude name="SlevomatCodingStandard.Functions.DisallowArrowFunction.DisallowedArrowFunction"/>
         <exclude name="SlevomatCodingStandard.Functions.RequireMultiLineCall"/>
         <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants.NonFullyQualified"/>
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions.NonFullyQualified"/>
         <exclude name="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces"/>
-        <exclude name="SlevomatCodingStandard.Classes.ParentCallSpacing.IncorrectLinesCountAfterLastControlStructure"/>
+        <exclude name="SlevomatCodingStandard.PHP.RequireNowdoc.RequiredNowdoc"/>
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing"/>
         <exclude name="Squiz.Commenting.VariableComment.MissingVar"/>
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>


### PR DESCRIPTION
`SlevomatCodingStandard` rules are throwing excessive amount of errors while committing code in https://github.com/conversionxl/institute-plugin but some of them do not fit our style.

I looked at couple of classes in that repository and identified the most common rules which I think should be excluded.