### PR TITLE
chore: bump slevomat from 6.4.1 to 8.4.0

### DIFF
--- a/CXL/ruleset.xml
+++ b/CXL/ruleset.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0"?>
 <ruleset name="CXL">
 
+    <!-- Show progress and output sniff names on violation, and add colours -->
+    <arg value="p" />
+    <arg name="colors" />
+    <arg value="s" />
+
     <!-- Spaces, not tabs. -->
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
 
-    <!--
-    We may also want to to include all the rules in WP standard.
-    -->
+    <!-- We may also want to include all the rules in WP standard -->
     <rule ref="WordPress-Core">
         <!-- Spaces, not tabs. -->
         <exclude name="Generic.WhiteSpace.DisallowSpaceIndent"/>
     </rule>
 
-    <rule ref="WordPress-Extra">
-    </rule>
+    <rule ref="WordPress-Extra" />
 
     <!--
     Allow wider vertical spacing coding style:
@@ -41,6 +43,9 @@
 
         <!-- Short ternary ftw. -->
         <exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+
+        <!-- Only English, no translations. -->
+        <exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
     </rule>
 
     <!--
@@ -74,6 +79,11 @@
         <severity>0</severity>
     </rule>
 
+    <!-- Suppress rule that reports many false positives. -->
+    <rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.VariableRedeclaration">
+        <severity>0</severity>
+    </rule>
+
     <rule ref="Squiz.Commenting">
         <!--
         "So far I have not found a use for file-level DocBlocks in closed-source software."
@@ -101,6 +111,8 @@
         -->
         <exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
         <exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch"/>
+        <exclude name="Squiz.Commenting.VariableComment.MissingVar"/>
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
     </rule>
 
     <rule ref="Generic.Commenting">
@@ -124,29 +136,49 @@
     -->
     <rule ref="SlevomatCodingStandard">
         <exclude name="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
+        <!-- Don't really care about group order. We kinda do, but not enough to enforce -->
+        <exclude name="SlevomatCodingStandard.Classes.ClassStructure.IncorrectGroupOrder" />
         <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaMagicConstant"/>
         <exclude name="SlevomatCodingStandard.Classes.ParentCallSpacing.IncorrectLinesCountAfterLastControlStructure"/>
+        <!-- We can't declare classes as abstract/final because we have plenty of instances where classes are both -->
+        <!-- used themselves, and also extended (EG: almost all of our Plugin main file) -->
+        <exclude name="SlevomatCodingStandard.Classes.RequireAbstractOrFinal"/>
+        <!-- There is actually a bug with this sniffer. If you use doc annotation to disable a rule, this sniffer (sometimes) throws an "Undefined index" error -->
         <exclude name="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode"/>
+        <!-- Multi or single line are both fine. Feel free to remove this exclusion if you prefer to enforce single line where they're possible -->
         <exclude name="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment.OneLinePropertyComment"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/>
+        <!-- Ternary shorthand is acceptable -->
         <exclude name="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator.DisallowedShortTernaryOperator"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing"/>
+        <!-- There are two rules which conflict. NewWithoutParentheses and UselessParentheses. One must be disabled -->
+        <!-- We allow new Class(); rather than new Class;-->
         <exclude name="SlevomatCodingStandard.ControlStructures.NewWithoutParentheses"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.NewWithParentheses.MissingParentheses"/>
+        <!-- Disabled by default, but you may be interested in reading up on Yoda conditions to see if it's -->
+        <!-- something that you would like to start using: https://en.wikipedia.org/wiki/Yoda_conditions -->
         <exclude name="SlevomatCodingStandard.ControlStructures.RequireYodaComparison"/>
         <exclude name="SlevomatCodingStandard.Files.LineLength"/>
         <exclude name="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/>
         <exclude name="SlevomatCodingStandard.Functions.DisallowArrowFunction.DisallowedArrowFunction"/>
+        <!-- Length does not determine complexity. We do not care if methods or files are long -->
+        <exclude name="SlevomatCodingStandard.Functions.FunctionLength.FunctionLength"/>
+        <!-- Also this is deprecated -->
+        <exclude name="SlevomatCodingStandard.Files.FunctionLength.FunctionLength"/>
         <exclude name="SlevomatCodingStandard.Functions.RequireMultiLineCall"/>
-        <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall"/>
+        <!-- We do not require trailing commas on multiline methods. -->
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+        <!-- Global constants and exceptions do not need to be fully qualified -->
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants.NonFullyQualified"/>
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions.NonFullyQualified"/>
+        <!-- We generally allow the use of any namespace -->
         <exclude name="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces"/>
+        <!-- Inline doc comments are fine. We use them quite often -->
+        <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
         <exclude name="SlevomatCodingStandard.PHP.RequireNowdoc.RequiredNowdoc"/>
+        <!-- Not something we do in CXL -->
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing"/>
-        <exclude name="Squiz.Commenting.VariableComment.MissingVar"/>
-        <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
@@ -175,8 +207,8 @@
         </properties>
     </rule>
 
-    <!-- Force phpDocs separation between different annotations and remove extra `*` -->
-    <!-- Require specific order of phpDoc annotations with empty newline between specific groups -->
+    <!-- Force phpDocs separation between different annotations and remove extra `*`. -->
+    <!-- Require specific order of phpDoc annotations with empty newline between specific groups. -->
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
         <properties>
             <property name="linesCountBetweenAnnotationsGroups" value="1"/>
@@ -203,6 +235,22 @@
 					@dataProvider,
                 "/>
             </property>
+        </properties>
+    </rule>
+
+    <!-- Requires multiline ternary when line is too large. -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireMultiLineTernaryOperator">
+        <properties>
+            <property name="lineLengthLimit" value="120"/>
+        </properties>
+    </rule>
+
+
+    <!-- Complexity check often fails. -->
+    <!-- Each team/project can decide if they'd prefer to just tweak the complexity level rather than exclude this rule -->
+    <rule ref="SlevomatCodingStandard.Complexity.Cognitive">
+        <properties>
+            <property name="maxComplexity" value="10"/>
         </properties>
     </rule>
 

--- a/bin/phpcbf-fix-exit-0
+++ b/bin/phpcbf-fix-exit-0
@@ -12,6 +12,8 @@
 
 if (is_file(__DIR__.'/../../../squizlabs/php_codesniffer/autoload.php') === true) {
     include_once __DIR__.'/../../../squizlabs/php_codesniffer/autoload.php';
+} elseif (is_file(__DIR__.'/../vendor/squizlabs/php_codesniffer/autoload.php') === true) {
+    include_once __DIR__.'/../vendor/squizlabs/php_codesniffer/autoload.php';
 } else {
     include_once 'PHP/CodeSniffer/autoload.php';
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "sirbrillig/phpcs-variable-analysis": "^v2.10.1",
     "wp-coding-standards/wpcs": "^2.3",
-    "slevomat/coding-standard": "^6.4"
+    "slevomat/coding-standard": "^8.4.0"
   },
   "scripts": {
     "post-install-cmd": "\"vendor/bin/phpcs\" --config-set default_standard CXL"

--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,10 @@
   },
   "scripts": {
     "post-install-cmd": "\"vendor/bin/phpcs\" --config-set default_standard CXL"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,361 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d3251fd20fb60b8b4755dfa70656058a",
+    "packages": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "367a8d9d5f7da2a0136422d27ce8840583926955"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/367a8d9d5f7da2a0136422d27ce8840583926955",
+                "reference": "367a8d9d5f7da2a0136422d27ce8840583926955",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.7.0"
+            },
+            "time": "2022-08-09T12:23:23+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "ad2b0b57803a48bb3495777bee2a9a13c8e9da53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/ad2b0b57803a48bb3495777bee2a9a13c8e9da53",
+                "reference": "ad2b0b57803a48bb3495777bee2a9a13c8e9da53",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2022-08-16T22:19:00+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "02f27326be19633a1b6ba76745390bbf9a4be0b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/02f27326be19633a1b6ba76745390bbf9a4be0b6",
+                "reference": "02f27326be19633a1b6ba76745390bbf9a4be0b6",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": ">=1.7.0 <1.8.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.8.2",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
+                "phpstan/phpstan-strict-rules": "1.3.0",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.21"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-08-09T19:03:45+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2022-06-18T07:21:10+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
+}


### PR DESCRIPTION
CU-Task: https://app.clickup.com/t/30xcmqp

* This update brings performance to linting / formatting, at least I noticed some performance while formatting code.
* Also brings: `SlevomatCodingStandard.Complexity.Cognitive`
	ref: https://github.com/slevomat/coding-standard/commit/7a3febca6f784587aa9ea772f6de94c7cef8bbbe

---

Update:

v8.3.0
```markdown
- Added `SlevomatCodingStandard.Complexity.Cognitive` (thanks to [@bkdotcom](https://github.com/bkdotcom))
- Added `SlevomatCodingStandard.Files.FileLength` (thanks to [@bkdotcom](https://github.com/bkdotcom))
- Added `SlevomatCodingStandard.Classes.ClassLength` (thanks to [@bkdotcom](https://github.com/bkdotcom))
```

v8.2.0
```markdown
- Added `SlevomatCodingStandard.Classes.BackedEnumTypeSpacing`
```

v8.0.0

```markdown
## ⚠️BC breaks

- `SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing` renamed to `SlevomatCodingStandard.Classes.PropertyDeclaration`
- `SlevomatCodingStandard.Classes.ClassStructure`: Removed option `enableFinalMethods`
- Removed error `SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity`
```

v7.2.0
```markdown
-   Added `SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse`
-   Added `SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse`
```

v7.1.0
```markdown
- Added `SlevomatCodingStandard.Classes.RequireAbstractOrFinal` (thanks to [@roslov](https://github.com/roslov))
- Added `SlevomatCodingStandard.Exceptions.DisallowNonCapturingCatch` (thanks to [@olsavmic](https://github.com/olsavmic))
```

v7.0.0

```markdown
-   `RequireNonCapturingCatchSniff`: Requires non-capturing `catch` when the variable with exception is not used
-   `RequireNullSafeObjectOperatorSniff`: Requires using `?->` operator
-   `DisallowNullSafeObjectOperatorSniff`: Disallows using `?->` operator
-   `RequireTrailingCommaInDeclarationSniff`: Enforces trailing commas in multi-line declarations
-   `DisallowTrailingCommaInDeclarationSniff`: Disallows trailing commas in multi-line declarations
-   `RequireConstructorPropertyPromotionSniff`: Requires use of constructor property promotion
-   `DisallowConstructorPropertyPromotionSniff`: Disallows usage of constructor property promotion
-   `UnionTypeHintFormatSniff`: Checks format of union type hints
-   `DisallowNamedArgumentsSniff`: Disallows usage of named arguments
-   `DisallowTrailingCommaInCallSniff`: Disallows trailing commas in multi-line calls
-   `ForbiddenPublicPropertySniff`: Disallows using public properties (thanks to [@50bhan](https://github.com/50bhan))
-   `FunctionLengthSniff`: Disallows long function (thanks to [@50bhan](https://github.com/50bhan))

## ⚠️BC breaks

-   `PropertyTypeHintSpacingSniff`: Removed `CODE_NO_SPACE_BEFORE_TYPE_HINT` because it's not possible on PHP 8
-   `DeclareStrictTypesSniff`: Options renamed and modifed, see [README](https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintsdeclarestricttypes-)
-   `TrailingCommaInCallSniff` renamed to `RequireTrailingCommaInCallSniff`
-   Removed deprecated `UnusedPrivateElementsSniff`
-   Removed `FullyQualifiedClassNameAfterKeywordSniff`
-   `ReferenceUsedNamesOnlySniff`: Removed option `fullyQualifiedKeywords`
-   `BlockControlStructureSpacingSniff`: Options renamed and modified, see [README](https://github.com/slevomat/coding-standard#slevomatcodingstandardcontrolstructuresblockcontrolstructurespacing-)
-   `JumpStatementsSpacingSniff`: Options renamed and modified, see [README](https://github.com/slevomat/coding-standard#slevomatcodingstandardcontrolstructuresjumpstatementsspacing-)
-   `ParentCallSpacingSniff`: Shorter options names, see [README](https://github.com/slevomat/coding-standard#slevomatcodingstandardclassesparentcallspacing-)
-   All helpers are marked as internal
-   `UselessFunctionDocCommentSniff`: Removed suppress support
```
