### PR TITLE
chore: exclude `...UselessInheritDocComment.UselessInheritDocComment`

### DIFF
--- a/CXL/ruleset.xml
+++ b/CXL/ruleset.xml
@@ -149,6 +149,7 @@
         <exclude name="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment.OneLinePropertyComment"/>
         <!-- We allow multiline doc comment for class or method when there's only 1 annotation present -->
         <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment.MultiLineDocComment"/>
+        <exclude name="SlevomatCodingStandard.Commenting.UselessInheritDocComment.UselessInheritDocComment"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/>
         <!-- Ternary shorthand is acceptable -->
         <exclude name="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator.DisallowedShortTernaryOperator"/>


### PR DESCRIPTION
`SlevomatCodingStandard.Commenting.UselessInheritDocComment.UselessInheritDocComment`

It is not clear what "useless" means.

Additionally causes `Squiz.Commenting.FunctionComment.Missing` error on commit quality check as `phpcbf` deletes the comment.

![Screenshot 2022-09-26 at 15 26 08](https://user-images.githubusercontent.com/5165721/192288564-58bd7bc0-8061-4757-b9ea-7df70c114911.png)
![Screenshot 2022-09-26 at 15 26 17](https://user-images.githubusercontent.com/5165721/192288570-39fd96ad-4058-4546-af90-5f406b2bcf78.png)
